### PR TITLE
Add article on moving from a doer to a leader

### DIFF
--- a/recommended-readings.md
+++ b/recommended-readings.md
@@ -53,6 +53,8 @@ Here's a list of resources I have personally found helpful. I include the Blinki
   - We are still doing phrasing and it's important. Communication is so important as a manager
   
 ### Technical leadership outside of management
+- [Are You Sabotaging Your Career By Being Perceived as a Doer and Not a Leader?](https://medium.com/swlh/are-you-sabotaging-your-career-by-being-perceived-as-a-doer-and-not-a-leader-d7a5693d0e68) (article)
+  - Article helpful particularly for staff engineers or staff hopefuls who are struggling to move from doing the work to unblocking people and becoming a leader
 - [Manager's Path](https://www.amazon.com/Managers-Path-Leaders-Navigating-Growth/dp/1491973897)
   - Highly recommend the section on how to be a tech lead 
 - [Not all engineering leaders are managers](https://leaddev.com/not-all-engineering-leaders-are-engineering-managers) (article) 


### PR DESCRIPTION
A common struggle I see when folks are moving up in their career to staff engineer/manager is the shift from being a prolific doer to being a leader. Skills that had been working in the past are suddenly not enough to get you to the next level. This is a great article discussing that shift with tangible action items on how to start leading more