### PR TITLE
Add staff engineer questions and resources

### DIFF
--- a/recommended-readings.md
+++ b/recommended-readings.md
@@ -42,6 +42,8 @@ Here's a list of resources I have personally found helpful. I include the Blinki
   - Tips and tricks on how to run more effective meetings
 - [How to set goals with your engineers that don't totally suck](https://link.medium.com/2spD8XpLv3) (article)
   - My thoughts and structure on how to have effective goals and useful 1:1s
+- [How to (slowly) build trust with your staff engineers](https://leaddev.com/culture-engagement-motivation/how-slowly-build-trust-your-staff-engineers) (article)
+  - Great list of questions to add to your 1:1s with your staff engineers 
 - [Interview with Danielle Leong: Ask vs Guess culture](https://fellow.app/supermanagers/danielle-leong-github-ask-versus-guess-culture/) (podcast)
   - Podcast that I'm on discussing how to improve psychological safety and emotional intelligence on your teams 
 - [Manager's Path](https://www.amazon.com/Managers-Path-Leaders-Navigating-Growth/dp/1491973897) (book)

--- a/templates/staff-eng-1-on-1s.md
+++ b/templates/staff-eng-1-on-1s.md
@@ -1,0 +1,18 @@
+# Staff engineer 1:1s 
+
+Staff engineers require a bit more high level questions in order to maximize time together and see what needs help in your organization that you may not be seeing. These heavily inspired by this [great article](https://leaddev.com/culture-engagement-motivation/how-slowly-build-trust-your-staff-engineers) and [Plucky 1:1 cards](https://shop.beplucky.com/products/the-plucky-1-1-starter-pack).
+
+- How do you spend your time? And given how you spend your time, what gives you energy vs what drains your energy?
+- How do you scale your impact? What strategies are you working on to scale your impact as a very senior engineer within the org? Are there engineers that you’d like to grow to be the next in line, etc?
+- Are there any technical decisions that came back to haunt us?
+- Is there misalignment anywhere? 
+- We’re always trying to do the best thing when we innovate and evolve our platform; is there a role or position that you would like us to hire to help you ‘be the best’?
+- Are there any interesting documents that outline recent retrospectives or incident post-mortems that I should read up on?
+- What can we do now that would make our lives better in six months?
+- How can I help? 
+- Who is the most stressed out person in the team/org? 
+- What has worked well in the past? 
+- If you had a month to fix whatever you wanted, what would you fix? 
+- How is morale on the team?
+- Is it clear what your role is on the team? In the engineering org? 
+- Do you feel like it's clear how to succeed as a staff engineer in the wider engineering organization? 


### PR DESCRIPTION
Great questions to ask your staff engineers to build trust and see what areas they have identified as needing your help. 

Adds a link to a LeadDev article and introduces a new template for 1:1s 